### PR TITLE
Implement project context menu with rename, delete, and export functionality

### DIFF
--- a/content_script/components/ProjectContextMenu.tsx
+++ b/content_script/components/ProjectContextMenu.tsx
@@ -1,0 +1,724 @@
+import React, { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { motion } from "framer-motion";
+import {
+  Edit3,
+  Trash2,
+  Download,
+  AlertTriangle,
+} from "lucide-react";
+import JSZip from "jszip";
+import { useUnifiedState } from "../context/UnifiedStateProvider";
+import { eventBus, InternalEventTypes } from "../messaging/InternalEventBus";
+import { RenameModal } from "./RenameModal";
+import { UnifiedProject } from "../../shared/types";
+import { projectOperations } from "../../shared/unified-db";
+
+interface Props {
+  x: number;
+  y: number;
+  project: UnifiedProject;
+  onClose: () => void;
+}
+
+export function ProjectContextMenu({ x, y, project, onClose }: Props) {
+  const { dispatch } = useUnifiedState();
+  const [isRenameModalOpen, setRenameModalOpen] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteCanvasAction, setDeleteCanvasAction] = useState<'keep' | 'delete'>('keep');
+  const menuRef = useRef<HTMLDivElement>(null);
+  const deleteModalRef = useRef<HTMLDivElement>(null);
+
+  // Position menu to stay within viewport
+  const [position, setPosition] = useState({ x, y });
+
+  useEffect(() => {
+    if (menuRef.current) {
+      const rect = menuRef.current.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+
+      let adjustedX = x;
+      let adjustedY = y;
+
+      // Adjust horizontal position
+      if (x + rect.width > viewportWidth - 16) {
+        adjustedX = viewportWidth - rect.width - 16;
+      }
+
+      // Adjust vertical position
+      if (y + rect.height > viewportHeight - 16) {
+        adjustedY = viewportHeight - rect.height - 16;
+      }
+
+      // Ensure menu is not off-screen on the left or top
+      adjustedX = Math.max(16, adjustedX);
+      adjustedY = Math.max(16, adjustedY);
+
+      setPosition({ x: adjustedX, y: adjustedY });
+    }
+  }, [x, y]);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        deleteModalRef.current &&
+        !deleteModalRef.current.contains(e.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    // Delay adding listeners to prevent immediate close
+    const timeoutId = setTimeout(() => {
+      document.addEventListener("mousedown", handleClickOutside);
+    }, 100);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleEscape = () => {
+      if (showDeleteConfirm) {
+        setShowDeleteConfirm(false);
+      } else if (isRenameModalOpen) {
+        setRenameModalOpen(false);
+      } else {
+        onClose();
+      }
+    };
+
+    const unsubscribe = eventBus.on(
+      InternalEventTypes.ESCAPE_PRESSED,
+      handleEscape,
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, [showDeleteConfirm, isRenameModalOpen, onClose]);
+
+  // Focus management for delete modal
+  useEffect(() => {
+    if (showDeleteConfirm && deleteModalRef.current) {
+      deleteModalRef.current.focus();
+    }
+  }, [showDeleteConfirm]);
+
+  const handleRename = async (newName: string) => {
+    try {
+      const updatedProject = await projectOperations.renameProject(project.id, newName);
+
+      // Update state
+      dispatch({ type: "UPDATE_PROJECT", payload: updatedProject });
+
+      // Emit event
+      eventBus.emit(InternalEventTypes.PROJECT_RENAME_REQUEST, {
+        projectId: project.id,
+        oldName: project.name,
+        newName: newName,
+      });
+
+      console.log("Project renamed successfully:", newName);
+    } catch (error) {
+      console.error("Failed to rename project:", error);
+      alert("Failed to rename project. Please try again.");
+    }
+  };
+
+  const handleDeleteConfirm = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    try {
+      const result = await projectOperations.deleteProjectWithOptions(
+        project.id,
+        deleteCanvasAction
+      );
+
+      // Update state with canvas action info
+      dispatch({
+        type: "DELETE_PROJECT",
+        payload: {
+          projectId: project.id,
+          canvasAction: deleteCanvasAction
+        }
+      });
+
+      // Emit event
+      eventBus.emit(InternalEventTypes.PROJECT_DELETE_REQUEST, {
+        project,
+        canvasAction: deleteCanvasAction,
+      });
+
+      console.log(`Project deleted successfully. ${result.deletedCanvasCount} canvases ${deleteCanvasAction === 'delete' ? 'deleted' : 'moved to unorganized'}.`);
+
+      // Close modal and context menu
+      setShowDeleteConfirm(false);
+      onClose();
+    } catch (error) {
+      console.error("Failed to delete project:", error);
+      alert("Failed to delete project. Please try again.");
+      // Reset modal state on error
+      setShowDeleteConfirm(false);
+      setDeleteCanvasAction('keep');
+    }
+  };
+
+  const handleExport = async () => {
+    try {
+      const exportData = await projectOperations.exportProject(project.id);
+
+      // Create ZIP file structure
+      const zip = new JSZip();
+
+      // Add project metadata
+      const projectMetadata = {
+        id: exportData.project.id,
+        name: exportData.project.name,
+        description: exportData.project.description || "",
+        color: exportData.project.color,
+        createdAt: exportData.project.createdAt,
+        updatedAt: exportData.project.updatedAt,
+        canvasCount: exportData.canvases.length,
+      };
+
+      zip.file("project.json", JSON.stringify(projectMetadata, null, 2));
+
+      // Create canvases directory
+      const canvasesFolder = zip.folder("canvases");
+      if (!canvasesFolder) {
+        throw new Error("Failed to create canvases folder");
+      }
+
+      // Add each canvas as an individual .excalidraw file
+      exportData.canvases.forEach((canvas) => {
+        const canvasData = {
+          type: "excalidraw",
+          version: 2,
+          source: "https://excalidraw.com",
+          elements: canvas.elements || [],
+          appState: canvas.appState || {
+            theme: "light",
+            viewBackgroundColor: "#ffffff",
+            currentItemStrokeColor: "#000000",
+            currentItemBackgroundColor: "transparent",
+            currentItemFillStyle: "hachure",
+            currentItemStrokeWidth: 1,
+            currentItemStrokeStyle: "solid",
+            currentItemRoughness: 1,
+            currentItemOpacity: 100,
+            currentItemFontSize: 20,
+            currentItemFontFamily: 1,
+            currentItemTextAlign: "left",
+            currentItemStartArrowhead: null,
+            currentItemEndArrowhead: "arrow",
+            scrollX: 0,
+            scrollY: 0,
+            zoom: { value: 1 },
+            currentItemLinearStrokeSharpness: "round",
+            gridSize: null,
+            colorPalette: {},
+          },
+          files: {},
+        };
+
+        const filename = `canvas-${canvas.id}.excalidraw`;
+        canvasesFolder.file(filename, JSON.stringify(canvasData, null, 2));
+      });
+
+      // Add export manifest
+      const manifest = {
+        exportVersion: "1.0.0",
+        exportedAt: exportData.exportedAt,
+        exportedBy: "Excali Organizer Extension",
+        projectName: exportData.project.name,
+        canvasCount: exportData.canvases.length,
+        format: "zip",
+        compatibility: {
+          excalidraw: "^0.18.0",
+          excaliOrganizer: "^1.0.0",
+        },
+      };
+
+      zip.file("manifest.json", JSON.stringify(manifest, null, 2));
+
+      // Generate ZIP blob and download
+      const zipBlob = await zip.generateAsync({
+        type: "blob",
+        compression: "DEFLATE",
+        compressionOptions: { level: 6 }
+      });
+
+      const url = URL.createObjectURL(zipBlob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${project.name
+        .replace(/[^a-z0-9]/gi, "_")
+        .toLowerCase()}_project.zip`;
+      a.click();
+      URL.revokeObjectURL(url);
+
+      // Emit event
+      eventBus.emit(InternalEventTypes.PROJECT_EXPORT_REQUEST, {
+        project,
+      });
+
+      console.log("Project exported successfully as ZIP:", project.name);
+    } catch (error) {
+      console.error("Failed to export project:", error);
+      alert("Failed to export project. Please try again.");
+    }
+    onClose();
+  };
+
+  const canvasCount = project.canvasIds?.length || 0;
+
+  const menuStyles: React.CSSProperties = {
+    position: "fixed",
+    left: position.x,
+    top: position.y,
+    background: "var(--theme-bg-primary, #ffffff)",
+    border: "1px solid var(--theme-border-primary, rgba(0, 0, 0, 0.1))",
+    borderRadius: "8px",
+    boxShadow: "var(--theme-shadow-lg, 0 8px 32px rgba(0, 0, 0, 0.1))",
+    minWidth: "200px",
+    padding: "8px 0",
+    zIndex: 9999999,
+    pointerEvents: "auto",
+  };
+
+  const menuItemStyles: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "12px",
+    padding: "10px 16px",
+    background: "none",
+    border: "none",
+    width: "100%",
+    textAlign: "left",
+    fontSize: "14px",
+    color: "var(--theme-text-primary)",
+    cursor: "pointer",
+    transition: "background-color 0.15s ease",
+  };
+
+  const confirmModalStyles: React.CSSProperties = {
+    // Removed manual positioning to rely on overlay's flex centering
+    background: "var(--theme-bg-primary, #ffffff)",
+    border: "1px solid var(--theme-border-primary, rgba(0, 0, 0, 0.1))",
+    borderRadius: "16px",
+    boxShadow: "var(--theme-shadow-lg, 0 20px 40px rgba(0, 0, 0, 0.15))",
+    padding: "0",
+    width: "480px",
+    maxWidth: "90vw",
+    maxHeight: "90vh",
+    overflow: "hidden",
+    zIndex: 10000000,
+    pointerEvents: "auto",
+  };
+
+  const overlayStyles: React.CSSProperties = {
+    position: "fixed",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: "rgba(0, 0, 0, 0.6)",
+    zIndex: 9999999,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "20px",
+    backdropFilter: "blur(4px)",
+  };
+
+  return createPortal(
+    <>
+      <motion.div
+        ref={menuRef}
+        style={menuStyles}
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.9 }}
+        transition={{ duration: 0.15 }}
+      >
+        <button
+          style={menuItemStyles}
+          onClick={() => setRenameModalOpen(true)}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = "var(--theme-bg-hover)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "none";
+          }}
+        >
+          <Edit3 size={16} />
+          Rename
+          <span
+            style={{
+              marginLeft: "auto",
+              fontSize: "12px",
+              color: "var(--theme-text-secondary)",
+            }}
+          >
+            F2
+          </span>
+        </button>
+
+        <div
+          style={{
+            height: "1px",
+            background: "var(--theme-border-secondary)",
+            margin: "4px 0",
+          }}
+        />
+
+        <button
+          style={menuItemStyles}
+          onClick={handleExport}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = "var(--theme-bg-hover)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "none";
+          }}
+        >
+          <Download size={16} />
+          Export Project
+          <span
+            style={{
+              marginLeft: "auto",
+              fontSize: "12px",
+              color: "var(--theme-text-secondary)",
+            }}
+          >
+            Ctrl+E
+          </span>
+        </button>
+
+        <div
+          style={{
+            height: "1px",
+            background: "var(--theme-border-secondary)",
+            margin: "4px 0",
+          }}
+        />
+
+        <button
+          style={{
+            ...menuItemStyles,
+            color: "var(--theme-error, #ef4444)",
+          }}
+          onClick={() => setShowDeleteConfirm(true)}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background =
+              "var(--theme-error-bg, rgba(239, 68, 68, 0.1))";
+            e.currentTarget.style.color = "var(--theme-error, #ef4444)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "none";
+            e.currentTarget.style.color = "var(--theme-error, #ef4444)";
+          }}
+        >
+          <Trash2 size={16} />
+          Delete Project
+          <span
+            style={{
+              marginLeft: "auto",
+              fontSize: "12px",
+              opacity: 0.7,
+            }}
+          >
+            Delete
+          </span>
+        </button>
+      </motion.div>
+
+      {/* Rename Modal */}
+      {isRenameModalOpen && (
+        <RenameModal
+          currentName={project.name}
+          onRename={handleRename}
+          onClose={() => setRenameModalOpen(false)}
+        />
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {showDeleteConfirm && (
+        <div
+          style={overlayStyles}
+          onClick={(e) => {
+            // Only close if clicking directly on the overlay, not on the modal content
+            if (e.target === e.currentTarget) {
+              setShowDeleteConfirm(false);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setShowDeleteConfirm(false);
+            }
+          }}
+          tabIndex={-1}
+        >
+          <motion.div
+            ref={deleteModalRef}
+            style={confirmModalStyles}
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            onClick={(e) => {
+              // Prevent modal content clicks from bubbling to overlay
+              e.stopPropagation();
+            }}
+          >
+            {/* Header */}
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "16px",
+              padding: "24px 24px 0 24px",
+              marginBottom: "20px"
+            }}>
+              <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "48px",
+                height: "48px",
+                borderRadius: "12px",
+                background: "var(--theme-error-bg, rgba(239, 68, 68, 0.1))",
+              }}>
+                <AlertTriangle size={24} style={{ color: "var(--theme-error, #ef4444)" }} />
+              </div>
+              <div>
+                <h3 style={{
+                  margin: 0,
+                  fontSize: "20px",
+                  fontWeight: "700",
+                  color: "var(--theme-text-primary, #1f2937)",
+                  lineHeight: "1.2"
+                }}>
+                  Delete Project
+                </h3>
+                <p style={{
+                  margin: "4px 0 0 0",
+                  fontSize: "14px",
+                  color: "var(--theme-text-secondary, #6b7280)",
+                  lineHeight: "1.4"
+                }}>
+                  This action cannot be undone
+                </p>
+              </div>
+            </div>
+
+            {/* Content */}
+            <div style={{ padding: "0 24px", marginBottom: "24px" }}>
+              <p style={{
+                margin: "0 0 20px 0",
+                fontSize: "16px",
+                color: "var(--theme-text-primary, #1f2937)",
+                lineHeight: "1.5"
+              }}>
+                Are you sure you want to delete "<strong style={{ color: "var(--theme-text-primary, #1f2937)" }}>{project.name}</strong>"?
+              </p>
+
+              {canvasCount > 0 && (
+                <div style={{
+                  padding: "20px",
+                  borderRadius: "12px",
+                  background: "var(--theme-bg-tertiary, #f8f9fa)",
+                  border: "1px solid var(--theme-border-secondary, rgba(0, 0, 0, 0.08))"
+                }}>
+                  <p style={{
+                    margin: "0 0 16px 0",
+                    fontSize: "15px",
+                    fontWeight: "600",
+                    color: "var(--theme-text-primary, #1f2937)"
+                  }}>
+                    This project contains <strong>{canvasCount}</strong> canvas{canvasCount !== 1 ? 'es' : ''}
+                  </p>
+
+                  <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: "12px",
+                        cursor: "pointer",
+                        padding: "12px",
+                        borderRadius: "8px",
+                        background: deleteCanvasAction === 'keep' ? "var(--theme-accent-primary, #6366f1)" : "var(--theme-bg-primary, #ffffff)",
+                        color: deleteCanvasAction === 'keep' ? "white" : "var(--theme-text-primary, #1f2937)",
+                        border: `2px solid ${deleteCanvasAction === 'keep' ? "var(--theme-accent-primary, #6366f1)" : "var(--theme-border-primary, rgba(0, 0, 0, 0.1))"}`,
+                        transition: "all 0.15s ease"
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setDeleteCanvasAction('keep');
+                      }}
+                    >
+                      <input
+                        type="radio"
+                        name="canvasAction"
+                        value="keep"
+                        checked={deleteCanvasAction === 'keep'}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          setDeleteCanvasAction('keep');
+                        }}
+                        style={{
+                          margin: "2px 0 0 0",
+                          accentColor: deleteCanvasAction === 'keep' ? "white" : "var(--theme-accent-primary, #6366f1)",
+                          cursor: "pointer",
+                        }}
+                      />
+                      <div>
+                        <div style={{ fontSize: "15px", fontWeight: "500", marginBottom: "4px" }}>
+                          Keep canvases
+                        </div>
+                        <div style={{
+                          fontSize: "13px",
+                          opacity: deleteCanvasAction === 'keep' ? 0.9 : 0.7
+                        }}>
+                          Move all canvases to unorganized folder
+                        </div>
+                      </div>
+                    </div>
+
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: "12px",
+                        cursor: "pointer",
+                        padding: "12px",
+                        borderRadius: "8px",
+                        background: deleteCanvasAction === 'delete' ? "var(--theme-error, #ef4444)" : "var(--theme-bg-primary, #ffffff)",
+                        color: deleteCanvasAction === 'delete' ? "white" : "var(--theme-text-primary, #1f2937)",
+                        border: `2px solid ${deleteCanvasAction === 'delete' ? "var(--theme-error, #ef4444)" : "var(--theme-border-primary, rgba(0, 0, 0, 0.1))"}`,
+                        transition: "all 0.15s ease"
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        setDeleteCanvasAction('delete');
+                      }}
+                    >
+                      <input
+                        type="radio"
+                        name="canvasAction"
+                        value="delete"
+                        checked={deleteCanvasAction === 'delete'}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          setDeleteCanvasAction('delete');
+                        }}
+                        style={{
+                          margin: "2px 0 0 0",
+                          accentColor: deleteCanvasAction === 'delete' ? "white" : "var(--theme-error, #ef4444)",
+                          cursor: "pointer",
+                        }}
+                      />
+                      <div>
+                        <div style={{ fontSize: "15px", fontWeight: "500", marginBottom: "4px" }}>
+                          Delete all canvases
+                        </div>
+                        <div style={{
+                          fontSize: "13px",
+                          opacity: deleteCanvasAction === 'delete' ? 0.9 : 0.7
+                        }}>
+                          Permanently delete all {canvasCount} canvas{canvasCount !== 1 ? 'es' : ''}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Footer */}
+            <div style={{
+              display: "flex",
+              gap: "12px",
+              justifyContent: "flex-end",
+              padding: "0 24px 24px 24px",
+              borderTop: "1px solid var(--theme-border-secondary, rgba(0, 0, 0, 0.08))",
+              paddingTop: "20px"
+            }}>
+              <button
+                style={{
+                  padding: "12px 20px",
+                  border: "1px solid var(--theme-border-primary, rgba(0, 0, 0, 0.1))",
+                  borderRadius: "10px",
+                  background: "var(--theme-bg-primary, #ffffff)",
+                  color: "var(--theme-text-primary, #1f2937)",
+                  fontSize: "15px",
+                  fontWeight: "500",
+                  cursor: "pointer",
+                  transition: "all 0.15s ease",
+                  minWidth: "80px"
+                }}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setShowDeleteConfirm(false);
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = "var(--theme-bg-hover, #f1f3f4)";
+                  e.currentTarget.style.transform = "translateY(-1px)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = "var(--theme-bg-primary, #ffffff)";
+                  e.currentTarget.style.transform = "translateY(0)";
+                }}
+              >
+                Cancel
+              </button>
+
+              <button
+                style={{
+                  padding: "12px 20px",
+                  border: "1px solid var(--theme-error, #ef4444)",
+                  borderRadius: "10px",
+                  background: "var(--theme-error, #ef4444)",
+                  color: "white",
+                  fontSize: "15px",
+                  fontWeight: "600",
+                  cursor: "pointer",
+                  transition: "all 0.15s ease",
+                  minWidth: "140px",
+                  boxShadow: "0 2px 8px rgba(239, 68, 68, 0.3)"
+                }}
+                onClick={handleDeleteConfirm}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = "#dc2626";
+                  e.currentTarget.style.borderColor = "#dc2626";
+                  e.currentTarget.style.transform = "translateY(-2px)";
+                  e.currentTarget.style.boxShadow = "0 4px 16px rgba(239, 68, 68, 0.4)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = "var(--theme-error, #ef4444)";
+                  e.currentTarget.style.borderColor = "var(--theme-error, #ef4444)";
+                  e.currentTarget.style.transform = "translateY(0)";
+                  e.currentTarget.style.boxShadow = "0 2px 8px rgba(239, 68, 68, 0.3)";
+                }}
+              >
+                Delete Project
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </>,
+    document.body,
+  );
+}

--- a/content_script/components/RenameModal.tsx
+++ b/content_script/components/RenameModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "framer-motion";
+import { eventBus, InternalEventTypes } from "../messaging/InternalEventBus";
 
 interface Props {
   currentName: string;
@@ -18,8 +19,13 @@ export function RenameModal({ currentName, onRename, onClose }: Props) {
       inputRef.current?.select();
     }, 100);
 
-    return () => clearTimeout(focusTimeout);
-  }, []);
+    const unsubscribe = eventBus.on(InternalEventTypes.ESCAPE_PRESSED, onClose);
+
+    return () => {
+      clearTimeout(focusTimeout);
+      unsubscribe();
+    };
+  }, [onClose]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/content_script/hooks/useKeyboardShortcuts.ts
+++ b/content_script/hooks/useKeyboardShortcuts.ts
@@ -138,7 +138,7 @@ export function useKeyboardShortcuts({
 
       if (visibleCanvases.length === 0) return;
 
-      let currentIndex = state.selectedCanvasId
+      const currentIndex = state.selectedCanvasId
         ?
         visibleCanvases.findIndex((c) => c.id === state.selectedCanvasId)
         : -1;

--- a/content_script/hooks/useThemeSync.ts
+++ b/content_script/hooks/useThemeSync.ts
@@ -190,8 +190,7 @@ export function useThemeSync() {
           try {
             const newState = JSON.parse(e.newValue);
             console.log(`New excalidraw-state theme: ${newState.theme}`);
-          } catch (error: unknown) {
-            // eslint-disable-line @typescript-eslint/no-unused-vars
+          } catch {
             console.log("Could not parse new storage value");
           }
         }

--- a/content_script/messaging/InternalEventBus.ts
+++ b/content_script/messaging/InternalEventBus.ts
@@ -40,6 +40,15 @@ export enum InternalEventTypes {
   SHOW_CONTEXT_MENU = "SHOW_CONTEXT_MENU",
   HIDE_CONTEXT_MENU = "HIDE_CONTEXT_MENU",
 
+  // Project context menu
+  PROJECT_CONTEXT_MENU_SHOW = "PROJECT_CONTEXT_MENU_SHOW",
+  PROJECT_CONTEXT_MENU_HIDE = "PROJECT_CONTEXT_MENU_HIDE",
+
+  // Project operations
+  PROJECT_RENAME_REQUEST = "PROJECT_RENAME_REQUEST",
+  PROJECT_DELETE_REQUEST = "PROJECT_DELETE_REQUEST",
+  PROJECT_EXPORT_REQUEST = "PROJECT_EXPORT_REQUEST",
+
   // Keyboard shortcuts and actions
   ESCAPE_PRESSED = "ESCAPE_PRESSED",
   SELECT_ALL_REQUEST = "SELECT_ALL_REQUEST",
@@ -92,6 +101,26 @@ export interface EventPayloads {
   };
   [InternalEventTypes.HIDE_CONTEXT_MENU]: null;
 
+  [InternalEventTypes.PROJECT_CONTEXT_MENU_SHOW]: {
+    x: number;
+    y: number;
+    project: UnifiedProject;
+  };
+  [InternalEventTypes.PROJECT_CONTEXT_MENU_HIDE]: null;
+
+  [InternalEventTypes.PROJECT_RENAME_REQUEST]: {
+    projectId: string;
+    oldName: string;
+    newName: string;
+  };
+  [InternalEventTypes.PROJECT_DELETE_REQUEST]: {
+    project: UnifiedProject;
+    canvasAction: 'keep' | 'delete';
+  };
+  [InternalEventTypes.PROJECT_EXPORT_REQUEST]: {
+    project: UnifiedProject;
+  };
+
   [InternalEventTypes.ESCAPE_PRESSED]: null;
   [InternalEventTypes.SELECT_ALL_REQUEST]: null;
   [InternalEventTypes.SHOW_HELP_OVERLAY]: null;
@@ -112,7 +141,9 @@ type EventHandler<T extends InternalEventTypes> = (
  * Provides type-safe event emission and subscription
  */
 export class InternalEventBus {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   private listeners: Map<string, Set<Function>> = new Map();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   private onceListeners: Map<string, Set<Function>> = new Map();
   private debugMode: boolean = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@excalidraw/excalidraw": "^0.18.0",
         "dexie": "^4.0.11",
         "framer-motion": "^12.19.2",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.525.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@types/chrome": "^0.0.329",
+        "@types/jszip": "^3.4.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.6.0",
@@ -2714,6 +2716,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jszip": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.1.tgz",
+      "integrity": "sha512-TezXjmf3lj+zQ651r6hPqvSScqBLvyPI9FxdXBqpEwBijNGQ2NXpaFW/7joGzveYkKQUil7iiDHLo6LV71Pc0A==",
+      "deprecated": "This is a stub types definition. jszip provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -3355,6 +3368,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cose-base": {
@@ -4540,6 +4559,12 @@
         "pica": "^7.1.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immutable": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
@@ -4632,6 +4657,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4736,6 +4767,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/katex": {
       "version": "0.16.22",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
@@ -4803,6 +4852,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/locate-path": {
@@ -5780,6 +5838,12 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5919,6 +5983,21 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -6064,6 +6143,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6112,6 +6197,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6146,6 +6237,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6429,6 +6529,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@excalidraw/excalidraw": "^0.18.0",
     "dexie": "^4.0.11",
     "framer-motion": "^12.19.2",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.525.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/shared/excalidraw-types.ts
+++ b/shared/excalidraw-types.ts
@@ -32,7 +32,7 @@ export interface ExcalidrawElement {
   updated: number;
   link: string | null;
   locked: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface AppState {
@@ -48,7 +48,7 @@ export interface AppState {
   selectedElementIds: Record<string, boolean>;
   editingGroupId: string | null;
   viewModeEnabled: boolean;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface BinaryFiles {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -84,6 +84,12 @@ export interface ContextMenuData {
   canvas: UnifiedCanvas;
 }
 
+export interface ProjectContextMenuData {
+  x: number;
+  y: number;
+  project: UnifiedProject;
+}
+
 export type File = UnifiedCanvas;
 export type Collection = UnifiedProject;
 export type Canvas = UnifiedCanvas;


### PR DESCRIPTION
Implement project context menu with rename, delete, and export functionality

  - Add ProjectContextMenu component with right-click support for projects
  - Implement project rename with validation and duplicate checking
  - Add project deletion with canvas handling options (keep/delete canvases)
  - Implement ZIP export functionality with JSZip for complete project backup
  - Fix delete modal radio button selection and confirmation button issues
  - Enhance event system with PROJECT_CONTEXT_MENU_* and project operation events
  - Add database operations: renameProject, deleteProjectWithOptions, exportProject
  - Improve state management for project deletion with canvas action support
  - Add expand/collapse chevron buttons for individual project control
  - Fix race condition in project collapse state management